### PR TITLE
Refine web search toggle

### DIFF
--- a/server/webSocketServer.ts
+++ b/server/webSocketServer.ts
@@ -5,6 +5,7 @@ export interface RequestPayload {
   text: string;
   model?: string;
   newChat: boolean;
+  webSearch?: boolean;
 }
 
 export type ResponseType = 'stop' | 'answer' | 'error';

--- a/services/chatGPTclient.ts
+++ b/services/chatGPTclient.ts
@@ -7,7 +7,7 @@ export interface ChatGPTResponse {
 
 export const askChatGPT = (text: string, newChat: boolean): Promise<ChatGPTResponse> =>
   new Promise((resolve, reject) => {
-    const payload: RequestPayload = { text, newChat };
+    const payload: RequestPayload = { text, newChat, webSearch: true };
 
     let theModel = '';
     webSocketServer.sendRequest(


### PR DESCRIPTION
## Summary
- add `webSearch` flag to `RequestPayload`
- always send `webSearch: true` from `askChatGPT`
- toggle web search in the user script only when enabled
- simplify `_ensureWebSearchState` signature

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c6e9940e48323a7c743caf9f4d251