### PR TITLE
Move selector constant into watcher

### DIFF
--- a/tampermonkey-script.js
+++ b/tampermonkey-script.js
@@ -12,11 +12,6 @@
   'use strict';
 
   const WS_URL         = 'ws://localhost:8765';
-  const STOP_BTN_SEL   = [
-    'button[data-testid="stop-button"]',
-    'button[aria-label="Stop streaming"]',
-    'button[aria-label="Stop generating"]'
-  ].join(',');
 
   const MODELS = [
     'gpt-4o',
@@ -253,6 +248,11 @@
     /* ----------- answer collection ---------- */
     // Watch DOM mutations to know when ChatGPT has finished responding
     _watchForAnswer() {
+      const STOP_BTN_SEL = [
+        'button[data-testid="stop-button"]',
+        'button[aria-label="Stop streaming"]',
+        'button[aria-label="Stop generating"]'
+      ].join(',');
       let started = false;
       log('watching for answer');
       this.observer?.disconnect();


### PR DESCRIPTION
## Summary
- clean up tampermonkey script
- move `STOP_BTN_SEL` inside `_watchForAnswer()` since it is only used there

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c81c89c648323933aa3991acd554a