### PR TITLE
Fix limit message detection

### DIFF
--- a/tampermonkey-script.js
+++ b/tampermonkey-script.js
@@ -294,7 +294,10 @@
      */
     _checkLimitMessage(article) {
       const button = article.querySelector('[data-testid="regenerate-thread-error-button"]');
-      const txt = article.textContent || '';
+      // Using innerText captures only the visible text which is more
+      // reliable for detecting usage limit messages that may include
+      // hidden screen-reader nodes.  Fallback to textContent if needed.
+      const txt = article.innerText || article.textContent || '';
       if (/hit your limit/i.test(txt) || /usage cap/i.test(txt) || /usage limit/i.test(txt) || button) {
         log('usage limit message detected');
         this._markUnavailable(MODELS[this.modelIndex]);


### PR DESCRIPTION
## Summary
- handle hidden nodes when scanning usage limit messages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687da05c326c8323b5e0fb50789a7d99